### PR TITLE
This changes allow the filter to handle measurements with a dynamic size

### DIFF
--- a/ukfom/traits/dof.hpp
+++ b/ukfom/traits/dof.hpp
@@ -35,6 +35,8 @@
 #ifndef __UKFOM_TRAITS_DOF_HPP__
 #define __UKFOM_TRAITS_DOF_HPP__
 
+#include <Eigen/Core>
+
 namespace ukfom {
 
 	template<typename Manifold>
@@ -48,6 +50,30 @@ namespace ukfom {
 	{
 		static const int value = n;
 	};
+
+        template<typename Derived, typename T>
+        void setZero(Eigen::MatrixBase<Derived>& cov, const T& type)
+        {
+                cov.setZero();
+        }
+
+        template<typename Scalar>
+        void setZero(Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cov, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& m)
+        {
+                cov.setZero(m.rows(), m.rows());
+        }
+
+        template<typename Scalar, int rows>
+        void setZero(Eigen::Matrix<Scalar, rows, Eigen::Dynamic>& cov, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& m)
+        {
+                cov.setZero(rows, m.rows());
+        }
+
+        template<typename Scalar, int cols>
+        void setZero(Eigen::Matrix<Scalar, Eigen::Dynamic, cols>& cov, const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& m)
+        {
+                cov.setZero(m.rows(), cols);
+        }
 
 } // namespace ukfom
 

--- a/ukfom/ukf.hpp
+++ b/ukfom/ukf.hpp
@@ -260,8 +260,9 @@ private:
 	sigma_points_mean(const std::vector<Matrix<scalar_type, measurement_rows, 1> > &Z) const
 	{
 		typedef Matrix<scalar_type, measurement_rows, 1> measurement;
-		
-		return std::accumulate(Z.begin(), Z.end(), measurement(measurement::Zero())) / Z.size();
+
+		measurement m(measurement::Zero(Z.begin()->rows()));
+		return std::accumulate(Z.begin(), Z.end(), m) / (scalar_type)Z.size();
 	}
 
 #ifdef VECT_H_
@@ -283,7 +284,8 @@ private:
 		typedef Matrix<scalar_type, cov_size, cov_size> cov_mat;
 		typedef Matrix<scalar_type, cov_size, 1> cov_col;
 		
-		cov_mat c(cov_mat::Zero());
+		cov_mat c;
+                setZero(c, mean);
 		
 		for (typename std::vector<T>::const_iterator Vi = V.begin(); Vi != V.end(); ++Vi)
 		{
@@ -305,7 +307,8 @@ private:
 
 		typedef Matrix<scalar_type, state::DOF, measurement_rows> cross_cov;
 
-		cross_cov c(cross_cov::Zero());
+		cross_cov c;
+                setZero(c, meanZ);
 
 		{
 			typename state_vector::const_iterator Xi = X.begin();


### PR DESCRIPTION
To identify the size of the dynamic matrix the rows() method is used. Since this method is only available on Eigen matrices is was necessary to overload the methods sigma_points_cov and sigma_points_cross_cov.

@chhtz what is your opinion on that? Do you see a more elegant solution?
